### PR TITLE
expand bug fix on android

### DIFF
--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -39,6 +39,7 @@ class Card extends React.PureComponent {
       <TouchableWithoutFeedback onPress={onPress}>
         <Animated.View style={containerStyle}>
           <View
+            renderToHardwareTextureAndroid={true}
             ref={instance => {
               this.container = instance;
             }}


### PR DESCRIPTION
Hi,
I found an error when expanding on Android.

I tracked the error and added the code below, and found that it works well on Android.
'renderToHardwareTextureAndroid = {true}'

Thanks for reading.